### PR TITLE
Correct fcm authorization header

### DIFF
--- a/lib/sparrow/fcm_v1.ex
+++ b/lib/sparrow/fcm_v1.ex
@@ -115,7 +115,7 @@ defmodule Sparrow.FCM.V1 do
           Sparrow.H2Worker.Authentication.TokenBased.t()
   def get_token_based_authentication do
     getter = fn ->
-      {"Authorization", "Bearer #{Sparrow.FCM.V1.TokenBearer.get_token()}"}
+      {"authorization", "Bearer #{Sparrow.FCM.V1.TokenBearer.get_token()}"}
     end
 
     Sparrow.H2Worker.Authentication.TokenBased.new(getter)

--- a/lib/sparrow/h2_worker/authentication/token_based.ex
+++ b/lib/sparrow/h2_worker/authentication/token_based.ex
@@ -9,11 +9,6 @@ defmodule Sparrow.H2Worker.Authentication.TokenBased do
   import Sparrow.APNS.TokenBearer
   # For APNS token can be obtanin from `Sparrow.APNS.TokenBearer.get_token(token_id)`
   token_getter = fn -> {"authorization", "bearer \#{get_token(token_id)}"} end
-
-  ## Example 2
-
-  # For FCM legacy
-  token_getter = fn -> {"Authorization", "key="my_dummy_fcm_token""} end
   """
   @type token_getter :: (() -> {String.t(), String.t()})
   @type t :: %__MODULE__{

--- a/test/api_test.exs
+++ b/test/api_test.exs
@@ -12,7 +12,7 @@ defmodule Sparrow.APITest do
 
       auth =
         Sparrow.H2Worker.Authentication.TokenBased.new(fn ->
-          {"Authorization", "my_dummy_fcm_token"}
+          {"authorization", "my_dummy_fcm_token"}
         end)
 
       pool_1_config =
@@ -52,7 +52,7 @@ defmodule Sparrow.APITest do
 
       auth =
         Sparrow.H2Worker.Authentication.TokenBased.new(fn ->
-          {"Authorization", "my_dummy_fcm_token"}
+          {"authorization", "my_dummy_fcm_token"}
         end)
 
       pool_1_config =
@@ -93,7 +93,7 @@ defmodule Sparrow.APITest do
 
       auth =
         Sparrow.H2Worker.Authentication.TokenBased.new(fn ->
-          {"Authorization", "my_dummy_fcm_token"}
+          {"authorization", "my_dummy_fcm_token"}
         end)
 
       pool_1_config =
@@ -128,7 +128,7 @@ defmodule Sparrow.APITest do
       add_new_pool: fn _, _, _ -> true end do
       auth =
         Sparrow.H2Worker.Authentication.TokenBased.new(fn ->
-          {"Authorization", "my_dummy_fcm_token"}
+          {"authorization", "my_dummy_fcm_token"}
         end)
 
       pool_1_config =
@@ -158,7 +158,7 @@ defmodule Sparrow.APITest do
       add_new_pool: fn _, _, _ -> true end do
       auth =
         Sparrow.H2Worker.Authentication.TokenBased.new(fn ->
-          {"Authorization", "my_dummy_fcm_token"}
+          {"authorization", "my_dummy_fcm_token"}
         end)
 
       pool_1_config =

--- a/test/fcm/v1/apns_config_test.exs
+++ b/test/fcm/v1/apns_config_test.exs
@@ -5,7 +5,7 @@ defmodule Sparrow.FCM.V1.APNSTest do
   alias Sparrow.FCM.V1.APNS
 
   test "apns config is built correcly" do
-    token_getter = fn -> {"Authorization", "Bearer dummy token"} end
+    token_getter = fn -> {"authorization", "Bearer dummy token"} end
 
     apns_notification =
       "dummy device token"

--- a/test/fcm/v1/notification_test.exs
+++ b/test/fcm/v1/notification_test.exs
@@ -127,7 +127,7 @@ defmodule Sparrow.FCM.V1.NotificationTest do
 
     apns =
       APNS.new(apns_notification, fn ->
-        {"Authorization", "Bearer dummy token"}
+        {"authorization", "Bearer dummy token"}
       end)
 
     fcm_notification =

--- a/test/sparrow_test.exs
+++ b/test/sparrow_test.exs
@@ -34,11 +34,6 @@ defmodule SparrowTest do
 
   test "Sparrow starts correctly", context do
     # DON'T COPY THIS TOKEN GETTER
-    # mock is needed due to bug in Google API:
-    # https://firebase.google.com/docs/cloud-messaging/auth-server
-    # is in conflict with
-    # https://tools.ietf.org/html/rfc7540#section-8.1.2
-    # DON'T COPY THIS TOKEN GETTER
     with_mock Sparrow.FCM.V1, [:passthrough],
       get_token_based_authentication: fn ->
         getter = fn ->
@@ -150,11 +145,6 @@ defmodule SparrowTest do
   end
 
   test "Sparrow starts correctly, FCM only", context do
-    # DON'T COPY THIS TOKEN GETTER
-    # mock is needed due to bug in Google API:
-    # https://firebase.google.com/docs/cloud-messaging/auth-server
-    # is in conflict with
-    # https://tools.ietf.org/html/rfc7540#section-8.1.2
     # DON'T COPY THIS TOKEN GETTER
     with_mock Sparrow.FCM.V1, [:passthrough],
       get_token_based_authentication: fn ->


### PR DESCRIPTION
This PR fixes FCM headers according to this specification https://tools.ietf.org/html/rfc7540#section-8.1.2