### PR TITLE
Add proccesing async response

### DIFF
--- a/lib/sparrow/apns.ex
+++ b/lib/sparrow/apns.ex
@@ -121,10 +121,16 @@ defmodule Sparrow.APNS do
           Sparrow.APNS.get_error_description(status, reason)
   end
   """
-  @spec process_response({:ok, {headers, body}} | {:error, reason}) ::
+  @spec process_response(:ok | {:ok, {headers, body}} | {:error, reason}) ::
           :ok
           | {:error,
              reason :: String.t() | nil | :request_timeout | :not_ready | reason}
+
+  def process_response(:ok) do
+    _ = Logger.debug(fn -> "action=handle_async_push_response" end)
+    :ok
+  end
+
   def process_response({:ok, {headers, body}}) do
     if {":status", "200"} in headers do
       _ =

--- a/lib/sparrow/fcm_v1.ex
+++ b/lib/sparrow/fcm_v1.ex
@@ -68,9 +68,15 @@ defmodule Sparrow.FCM.V1 do
     |> process_response()
   end
 
-  @spec process_response({:ok, {headers, body}} | {:error, reason}) ::
+  @spec process_response(:ok | {:ok, {headers, body}} | {:error, reason}) ::
           :ok
           | {:error, reason :: :request_timeout | :not_ready | reason}
+
+  def process_response(:ok) do
+    _ = Logger.debug(fn -> "action=handle_async_push_response" end)
+    :ok
+  end
+
   def process_response({:ok, {headers, body}}) do
     _ =
       Logger.debug(fn ->

--- a/test/apns/manual/real_ios_test.exs
+++ b/test/apns/manual/real_ios_test.exs
@@ -8,7 +8,7 @@ defmodule Sparrow.APNS.Manual.RealIosTest do
   @apns_topic System.get_env("APNSTOPIC")
   @key_id System.get_env("KEYID")
   @team_id System.get_env("TEAMID")
-  @p8_file_path "token.p8"
+  @p8_file_path "test/priv/tokens/apns_token.p8"
 
   @path_to_cert "test/priv/certs/Certificates1.pem"
   @path_to_key "test/priv/certs/key.pem"

--- a/test/apns/manual/real_ios_test.exs
+++ b/test/apns/manual/real_ios_test.exs
@@ -2,7 +2,6 @@ defmodule Sparrow.APNS.Manual.RealIosTest do
   use ExUnit.Case
 
   alias Sparrow.APNS.Notification
-  alias Sparrow.H2Worker.Config
 
   @device_token System.get_env("TOKENDEVICE")
   @apns_topic System.get_env("APNSTOPIC")

--- a/test/fcm/manual/real_android_test.exs
+++ b/test/fcm/manual/real_android_test.exs
@@ -16,17 +16,13 @@ defmodule Sparrow.FCM.Manual.RealAndroidTest do
 
   @tag :skip
   test "real android notification send" do
-    Sparrow.FCM.V1.TokenBearer.start_link(@path_to_json)
+    fcm = [
+      [
+        path_to_json: @path_to_json
+      ]
+    ]
 
-    {:ok, _pid} = Sparrow.PoolsWarden.start_link()
-
-    worker_config =
-      Sparrow.FCM.V1.get_token_based_authentication()
-      |> Sparrow.FCM.V1.get_h2worker_config()
-
-    {:ok, _pid} =
-      Sparrow.H2Worker.Pool.Config.new(worker_config)
-      |> Sparrow.H2Worker.Pool.start_link(:fcm, [:webpush])
+    start_sparrow_with_fcm_config(fcm)
 
     android =
       Sparrow.FCM.V1.Android.new()
@@ -43,8 +39,12 @@ defmodule Sparrow.FCM.Manual.RealAndroidTest do
       )
       |> Notification.add_android(android)
 
-    notification
-    |> Sparrow.API.push([:webpush])
-    |> IO.inspect()
+    assert :ok == Sparrow.API.push(notification)
+  end
+
+  defp start_sparrow_with_fcm_config(config) do
+    Application.stop(:sparrow)
+    Application.put_env(:sparrow, :fcm, config)
+    Application.start(:sparrow)
   end
 end

--- a/test/fcm/manual/real_webpush_test.exs
+++ b/test/fcm/manual/real_webpush_test.exs
@@ -34,7 +34,7 @@ defmodule Sparrow.FCM.Manual.RealWebpushTest do
       )
       |> Notification.add_webpush(webpush)
 
-    :ok = Sparrow.API.push(notification)
+    assert :ok == Sparrow.API.push(notification)
   end
 
   defp start_sparrow_with_fcm_config(config) do

--- a/test/sparrow_test.exs
+++ b/test/sparrow_test.exs
@@ -119,6 +119,12 @@ defmodule SparrowTest do
                |> Sparrow.APNS.Notification.add_title("dummy title")
                |> Sparrow.API.push()
 
+      assert :ok ==
+      "OkResponseHandler"
+      |> Sparrow.APNS.Notification.new(:prod)
+      |> Sparrow.APNS.Notification.add_title("dummy title")
+      |> Sparrow.API.push([],[is_sync: false])
+
       assert {:error, :configuration_error} ==
                "OkResponseHandler"
                |> Sparrow.APNS.Notification.new(:dev)
@@ -181,6 +187,7 @@ defmodule SparrowTest do
 
       assert :ok == Sparrow.API.push(notiifcation)
       assert :ok == Sparrow.API.push(notiifcation, [:yippee_ki_yay])
+      assert :ok == Sparrow.API.push(notiifcation, [], [is_sync: false])
 
       assert {:error, :configuration_error} ==
                Sparrow.API.push(notiifcation, [


### PR DESCRIPTION
The issue fixed is that:
`Sparrow.H2Worker.Pool.send_request(request, is_sync, timeout, strategy)` 
https://github.com/esl/sparrow/blob/5f3b1c5fe506b5d0042401641627e95ec793b3cc/lib/sparrow/h2_worker/pool.ex#L30-L37
with `is_sync` set to `false` returns `:ok` (message is sent to be pushed but we do not wait for result and return :ok immediately) but this result does not match any pattern of `Sparrow.APNS.process_response(response)`
https://github.com/esl/sparrow/blob/5f3b1c5fe506b5d0042401641627e95ec793b3cc/lib/sparrow/apns.ex#L124  
so it causes error in:
https://github.com/esl/sparrow/blob/5f3b1c5fe506b5d0042401641627e95ec793b3cc/lib/sparrow/apns.ex#L90-L96
and 
https://github.com/esl/sparrow/blob/5f3b1c5fe506b5d0042401641627e95ec793b3cc/lib/sparrow/fcm_v1.ex#L63-L68

and the solution is to add pattern like `(:ok) -> :ok` and extend tests for that case
