### PR TITLE
Extend APNS API

### DIFF
--- a/lib/sparrow/apns/notification.ex
+++ b/lib/sparrow/apns/notification.ex
@@ -41,7 +41,12 @@ defmodule Sparrow.APNS.Notification do
         ]
   @type aps_dictionary_opts :: [aps_dictionary_opt]
   @type aps_dictionary_key ::
-          :badge | :sound | :"content-available" | :category | :"thread-id"
+          :badge
+          | :sound
+          | :"content-available"
+          | :category
+          | :"thread-id"
+          | :"mutable-content"
   @type aps_dictionary_opt ::
           {:badge, integer}
           | {:sound, String.t()}
@@ -86,6 +91,14 @@ defmodule Sparrow.APNS.Notification do
       custom_data: [],
       type: type
     }
+  end
+
+  @doc """
+  Sets the `mutable-content` option of the aps dictionary to 1.
+  """
+  @spec add_mutable_content(__MODULE__.t()) :: __MODULE__.t()
+  def add_mutable_content(notification) do
+    add_aps_dictionary_opt(notification, :"mutable-content", 1)
   end
 
   @doc """
@@ -148,8 +161,7 @@ defmodule Sparrow.APNS.Notification do
   @doc """
   Sets the `subtitle-loc-args` option of the alert dictionary.
   """
-  @spec add_subtitle_loc_args(__MODULE__.t(), String.t() | json_array) ::
-          __MODULE__.t()
+  @spec add_subtitle_loc_args(__MODULE__.t(), [String.t()]) :: __MODULE__.t()
   def add_subtitle_loc_args(notification, value) do
     add_alert_opt(notification, :"subtitle-loc-args", value)
   end

--- a/lib/sparrow/apns/notification.ex
+++ b/lib/sparrow/apns/notification.ex
@@ -98,8 +98,9 @@ defmodule Sparrow.APNS.Notification do
 
   @doc """
   Sets the `sound` option of the aps dictionary.
+  Use `Sparrow.APNS.Notification.Sound` if you want this value to be dictionary.
   """
-  @spec add_sound(__MODULE__.t(), String.t()) :: __MODULE__.t()
+  @spec add_sound(__MODULE__.t(), String.t() | map) :: __MODULE__.t()
   def add_sound(notification, value) do
     add_aps_dictionary_opt(notification, :sound, value)
   end

--- a/lib/sparrow/apns/notification/sound.ex
+++ b/lib/sparrow/apns/notification/sound.ex
@@ -1,0 +1,40 @@
+defmodule Sparrow.APNS.Notification.Sound do
+  @moduledoc """
+  Helper to build sound dictionary for APNS notification.
+
+  ## Example
+
+    alias Sparrow.APNS.Notification.Sound
+    sound =
+      "chirp"
+      |> Sound.new()
+      |> Sound.add_critical()
+      |> Sound.add_volume(0.07)
+  """
+
+  @doc """
+  Method to create new sound.
+  """
+  @spec new(String.t()) :: map
+  def new(name) do
+    %{
+      "name" => name
+    }
+  end
+
+  @doc """
+  The critical alert flag. Set to 1 to enable the critical alert.
+  """
+  @spec add_critical(map) :: map
+  def add_critical(sound) do
+    Map.put(sound, "critical", 1)
+  end
+
+  @doc """
+    The volume for the critical alert’s sound. Set this to a value between 0.0 (silent) and 1.0 (full volume).
+  """
+  @spec add_volume(map, float) :: map
+  def add_volume(sound, volume) do
+    Map.put(sound, "volume", volume)
+  end
+end

--- a/test/apns_test.exs
+++ b/test/apns_test.exs
@@ -173,6 +173,7 @@ defmodule Sparrow.APNSTest do
         |> Notification.add_content_available(content_available)
         |> Notification.add_category(category)
         |> Notification.add_thread_id(thread_id)
+        |> Notification.add_mutable_content()
 
       assert :ok == Sparrow.APNS.push(@pool_name, notification)
 
@@ -192,6 +193,7 @@ defmodule Sparrow.APNSTest do
       assert content_available == Map.get(aps_opts, "content-available")
       assert category == Map.get(aps_opts, "category")
       assert thread_id == Map.get(aps_opts, "thread-id")
+      assert 1 == Map.get(aps_opts, "mutable-content")
     end
   end
 
@@ -199,7 +201,7 @@ defmodule Sparrow.APNSTest do
     title_loc_key = "title_loc_key of some kind"
     title_loc_args = "args loc titile"
     subtitle_loc_key = "subtitle_loc_key of some kind"
-    subtitle_loc_args = "subargs loc titile"
+    subtitle_loc_args = ["subargs loc titile", "c titile"]
     loc_args = " arg1 arg2"
     launch_image = "image lanch"
     loc_key = "loc_key value"

--- a/test/sparrow_test.exs
+++ b/test/sparrow_test.exs
@@ -120,10 +120,10 @@ defmodule SparrowTest do
                |> Sparrow.API.push()
 
       assert :ok ==
-      "OkResponseHandler"
-      |> Sparrow.APNS.Notification.new(:prod)
-      |> Sparrow.APNS.Notification.add_title("dummy title")
-      |> Sparrow.API.push([],[is_sync: false])
+               "OkResponseHandler"
+               |> Sparrow.APNS.Notification.new(:prod)
+               |> Sparrow.APNS.Notification.add_title("dummy title")
+               |> Sparrow.API.push([], is_sync: false)
 
       assert {:error, :configuration_error} ==
                "OkResponseHandler"
@@ -187,7 +187,7 @@ defmodule SparrowTest do
 
       assert :ok == Sparrow.API.push(notiifcation)
       assert :ok == Sparrow.API.push(notiifcation, [:yippee_ki_yay])
-      assert :ok == Sparrow.API.push(notiifcation, [], [is_sync: false])
+      assert :ok == Sparrow.API.push(notiifcation, [], is_sync: false)
 
       assert {:error, :configuration_error} ==
                Sparrow.API.push(notiifcation, [


### PR DESCRIPTION
This PR extends APNS API to add options that were found in https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification
but were not listed in
https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html#//apple_ref/doc/uid/TP40008194-CH17-SW1
some options were already implemented so it just fixes reaming.

Added changes:
1) for aps dictionary,  sound option was extended, now it can be a dictionary too (previously could be String only); sound dictionary builder added

2) for aps dictionary, mutable-content option was added

3) add_subtitle_loc_args spec is fixed