### PR TITLE
Read fcm project id from json

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,6 @@ Application.start(:sparrow)
     ```
     3.1 FCM
     ```elixir
-    @project_id "my-project-123"
     android =
         Sparrow.FCM.V1.Android.new()
         |> Sparrow.FCM.V1.Android.add_title("my first notification title")
@@ -300,7 +299,7 @@ Application.start(:sparrow)
         |> Sparrow.FCM.V1.Webpush.add_body("my first notification body")
       
     notification =
-        Sparrow.FCM.V1.Notification.new(:topic, "news", @project_id)
+        Sparrow.FCM.V1.Notification.new(:topic, "news")
         |> Sparrow.FCM.V1.Notification.add_android(android)
         |> Sparrow.FCM.V1.Notification.add_webpush(webpush)
         Sparrow.API.push()

--- a/lib/sparrow/api.ex
+++ b/lib/sparrow/api.ex
@@ -71,12 +71,18 @@ defmodule Sparrow.API do
     :fcm
   end
 
-  @spec do_push(atom, notification, Keyword.t()) :: sync_push_result | :ok
-  defp do_push(pool, notification = %Sparrow.APNS.Notification{}, opts) do
-    Sparrow.APNS.push(pool, notification, opts)
+  @spec do_push(pool_name :: atom, notification, Keyword.t()) ::
+          sync_push_result | :ok
+  defp do_push(pool_name, notification = %Sparrow.APNS.Notification{}, opts) do
+    Sparrow.APNS.push(pool_name, notification, opts)
   end
 
-  defp do_push(pool, notification = %Sparrow.FCM.V1.Notification{}, opts) do
-    Sparrow.FCM.V1.push(pool, notification, opts)
+  defp do_push(pool_name, notification = %Sparrow.FCM.V1.Notification{}, opts) do
+    project_id = Sparrow.FCM.V1.ProjectIdBearer.get_project_id(pool_name)
+
+    notification =
+      Sparrow.FCM.V1.Notification.add_project_id(notification, project_id)
+
+    Sparrow.FCM.V1.push(pool_name, notification, opts)
   end
 end

--- a/lib/sparrow/fcm/v1/notification.ex
+++ b/lib/sparrow/fcm/v1/notification.ex
@@ -14,7 +14,7 @@ defmodule Sparrow.FCM.V1.Notification do
   @type apns :: nil | Sparrow.FCM.V1.APNS.t()
   @type headers :: Request.headers()
   @type t :: %__MODULE__{
-          project_id: String.t(),
+          project_id: String.t() | nil,
           headers: headers,
           data: map,
           title: String.t() | nil,
@@ -57,7 +57,6 @@ defmodule Sparrow.FCM.V1.Notification do
   @spec new(
           target_type,
           String.t(),
-          String.t(),
           String.t() | nil,
           String.t() | nil,
           map
@@ -65,13 +64,12 @@ defmodule Sparrow.FCM.V1.Notification do
   def new(
         target_type,
         target,
-        project_id,
         title \\ nil,
         body \\ nil,
         data \\ %{}
       ) do
     %__MODULE__{
-      project_id: project_id,
+      project_id: nil,
       headers: @headers,
       data: data,
       title: title,
@@ -110,6 +108,8 @@ defmodule Sparrow.FCM.V1.Notification do
 
   @doc """
   Add `project_id` to `Sparrow.FCM.V1.Notification`.
+  WARNING This function is called automatically when pushing notification.
+  There is NO need to cally it manually when creating notiifcation.
   """
   @spec add_project_id(t, project_id :: String.t()) :: t
   def add_project_id(notification, project_id) do

--- a/lib/sparrow/fcm/v1/notification.ex
+++ b/lib/sparrow/fcm/v1/notification.ex
@@ -107,4 +107,12 @@ defmodule Sparrow.FCM.V1.Notification do
   def add_apns(notification, config) do
     %{notification | apns: config}
   end
+
+  @doc """
+  Add `project_id` to `Sparrow.FCM.V1.Notification`.
+  """
+  @spec add_project_id(t, project_id :: String.t()) :: t
+  def add_project_id(notification, project_id) do
+    %{notification | project_id: project_id}
+  end
 end

--- a/lib/sparrow/fcm/v1/notification.ex
+++ b/lib/sparrow/fcm/v1/notification.ex
@@ -69,7 +69,6 @@ defmodule Sparrow.FCM.V1.Notification do
         data \\ %{}
       ) do
     %__MODULE__{
-      project_id: nil,
       headers: @headers,
       data: data,
       title: title,

--- a/lib/sparrow/fcm/v1/pool/supervisor.ex
+++ b/lib/sparrow/fcm/v1/pool/supervisor.ex
@@ -16,6 +16,11 @@ defmodule Sparrow.FCM.V1.Pool.Supervisor do
   def init(raw_config) do
     {pool_config, pool_tags} = get_fcm_pool_config(raw_config)
 
+    Sparrow.FCM.V1.ProjectIdBearer.add_project_id(
+      raw_config[:path_to_json],
+      pool_config.pool_name
+    )
+
     children = [
       %{
         id: Sparrow.H2Worker.Pool,

--- a/lib/sparrow/fcm/v1/project_ids_bearer.ex
+++ b/lib/sparrow/fcm/v1/project_ids_bearer.ex
@@ -1,0 +1,73 @@
+defmodule Sparrow.FCM.V1.ProjectIdBearer do
+  @moduledoc """
+  Module providing FCM project id automaticly.
+  """
+  require Logger
+  use GenServer
+  @tab_name :fcm_project_ids
+
+  @spec get_project_id(atom) :: String.t() | nil
+  def get_project_id(h2_worker_pool) do
+    @tab_name
+    |> :ets.lookup(h2_worker_pool)
+    |> (fn [{_, project_id}] -> project_id end).()
+  end
+
+  @spec add_project_id(Path.t(), atom) :: true
+  def add_project_id(google_json_path, h2_worker_pool_name) do
+    GenServer.call(
+      __MODULE__,
+      {:add_project_id, google_json_path, h2_worker_pool_name}
+    )
+  end
+
+  def handle_call(
+        {:add_project_id, google_json_path, h2_worker_pool_name},
+        _from,
+        _state
+      ) do
+    json = File.read!(google_json_path)
+
+    _ =
+      Logger.debug(fn ->
+        "worker=fcm_project_id_bearer, action=read_json, result=success"
+      end)
+
+    project_id =
+      json
+      |> Jason.decode!()
+      |> Map.get("project_id")
+
+    _ =
+      Logger.debug(fn ->
+        "worker=fcm_project_id_bearer, action=exteract_project_id_from_json, project_id=#{
+          inspect(project_id)
+        }"
+      end)
+
+    :ets.insert(@tab_name, {h2_worker_pool_name, project_id})
+    {:reply, :ok, :ok}
+  end
+
+  @spec start_link :: GenServer.on_start()
+  def start_link do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  @spec start_link(any()) :: GenServer.on_start()
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  @spec init(any()) :: {:ok, :ok}
+  def init(_) do
+    @tab_name = :ets.new(@tab_name, [:set, :protected, :named_table])
+
+    _ =
+      Logger.info(fn ->
+        "worker=fcm_project_id_bearer, action=init, result=success"
+      end)
+
+    {:ok, :ok}
+  end
+end

--- a/lib/sparrow/fcm/v1/supervisor.ex
+++ b/lib/sparrow/fcm/v1/supervisor.ex
@@ -20,6 +20,7 @@ defmodule Sparrow.FCM.V1.Supervisor do
           {Sparrow.FCM.V1.TokenBearer, :start_link,
            [raw_fcm_config[:path_to_json]]}
       },
+      Sparrow.FCM.V1.ProjectIdBearer,
       {Sparrow.FCM.V1.Pool.Supervisor, raw_fcm_config}
     ]
 

--- a/lib/sparrow/fcm_v1.ex
+++ b/lib/sparrow/fcm_v1.ex
@@ -95,7 +95,7 @@ defmodule Sparrow.FCM.V1 do
     else
       status = get_status_from_headers(headers)
 
-      Logger.debug(fn ->
+      _ = Logger.debug(fn ->
         "action=handle_push_response, result=fail, status=#{inspect(status)}"
       end)
 

--- a/lib/sparrow/fcm_v1.ex
+++ b/lib/sparrow/fcm_v1.ex
@@ -95,6 +95,10 @@ defmodule Sparrow.FCM.V1 do
     else
       status = get_status_from_headers(headers)
 
+      Logger.debug(fn ->
+        "action=handle_push_response, result=fail, status=#{inspect(status)}"
+      end)
+
       reason =
         body
         |> get_reason_from_body()
@@ -102,7 +106,7 @@ defmodule Sparrow.FCM.V1 do
 
       _ =
         Logger.warn(fn ->
-          "action=handle_push_response, result=fail, status=#{inspect(status)}, response_body=#{
+          "action=handle_push_response, result=fail, response_body=#{
             inspect(body)
           }"
         end)

--- a/test/api_test.exs
+++ b/test/api_test.exs
@@ -11,10 +11,6 @@ defmodule Sparrow.APITest do
         assert n.project_id == @project_id
         :ok
       end,
-      push: fn _, n ->
-        assert n.project_id == @project_id
-        :ok
-      end,
       process_response: fn _ -> :ok end do
       Sparrow.PoolsWarden.start_link()
       Sparrow.FCM.V1.ProjectIdBearer.start_link()

--- a/test/fcm/v1/notification_test.exs
+++ b/test/fcm/v1/notification_test.exs
@@ -10,7 +10,6 @@ defmodule Sparrow.FCM.V1.NotificationTest do
   @title "test title"
   @body "test body"
   @target "test target"
-  @project_id "test project_id"
   @data %{:keyA => :valueA, :B => :b}
 
   test "notification without any config" do
@@ -18,13 +17,12 @@ defmodule Sparrow.FCM.V1.NotificationTest do
       Sparrow.FCM.V1.Notification.new(
         :token,
         @target,
-        @project_id,
         @title,
         @body,
         @data
       )
 
-    assert fcm_notification.project_id == @project_id
+    assert fcm_notification.project_id == nil
     assert fcm_notification.title == @title
     assert fcm_notification.body == @body
     assert fcm_notification.target == @target
@@ -35,7 +33,7 @@ defmodule Sparrow.FCM.V1.NotificationTest do
   end
 
   test "notification default values are set correctly" do
-    notification = Notification.new(:token, "dummy token", "project_id")
+    notification = Notification.new(:token, "dummy token")
 
     assert notification.title == nil
     assert notification.body == nil
@@ -43,8 +41,7 @@ defmodule Sparrow.FCM.V1.NotificationTest do
   end
 
   test "notification default values are set but to default value" do
-    notification =
-      Notification.new(:token, "dummy token", "project_id", nil, nil, %{})
+    notification = Notification.new(:token, "dummy token", nil, nil, %{})
 
     assert notification.title == nil
     assert notification.body == nil
@@ -56,7 +53,6 @@ defmodule Sparrow.FCM.V1.NotificationTest do
       Notification.new(
         :token,
         "dummy token",
-        "project_id",
         @title,
         @body,
         @data
@@ -77,14 +73,13 @@ defmodule Sparrow.FCM.V1.NotificationTest do
       Sparrow.FCM.V1.Notification.new(
         :token,
         @target,
-        @project_id,
         nil,
         nil,
         @data
       )
       |> Notification.add_android(android)
 
-    assert fcm_notification.project_id == @project_id
+    assert fcm_notification.project_id == nil
     assert fcm_notification.title == nil
     assert fcm_notification.body == nil
     assert fcm_notification.target == @target
@@ -101,14 +96,13 @@ defmodule Sparrow.FCM.V1.NotificationTest do
       Sparrow.FCM.V1.Notification.new(
         :token,
         @target,
-        @project_id,
         @title,
         @body,
         @data
       )
       |> Notification.add_webpush(webpush)
 
-    assert fcm_notification.project_id == @project_id
+    assert fcm_notification.project_id == nil
     assert fcm_notification.title == @title
     assert fcm_notification.body == @body
     assert fcm_notification.target == @target
@@ -134,14 +128,13 @@ defmodule Sparrow.FCM.V1.NotificationTest do
       Sparrow.FCM.V1.Notification.new(
         :token,
         @target,
-        @project_id,
         @title,
         @body,
         @data
       )
       |> Notification.add_apns(apns)
 
-    assert fcm_notification.project_id == @project_id
+    assert fcm_notification.project_id == nil
     assert fcm_notification.title == @title
     assert fcm_notification.body == @body
     assert fcm_notification.target == @target

--- a/test/fcmv1_test.exs
+++ b/test/fcmv1_test.exs
@@ -101,7 +101,7 @@ defmodule Sparrow.FCM.V1Test do
         send(self(), {:ok, {headers, r.body}})
         {:ok, {headers, r.body}}
       end do
-      notification = test_notification("EchoBodyHandler")
+      notification = test_notification()
 
       assert :ok == Sparrow.FCM.V1.push(@pool_name, notification)
 
@@ -129,7 +129,7 @@ defmodule Sparrow.FCM.V1Test do
         {:ok, {headers, r.body}}
       end do
       notification =
-        test_notification("EchoBodyHandler")
+        test_notification()
         |> Notification.add_android(test_android())
 
       assert :ok == Sparrow.FCM.V1.push(@pool_name, notification)
@@ -175,7 +175,7 @@ defmodule Sparrow.FCM.V1Test do
         {:ok, {headers, r.body}}
       end do
       notification =
-        test_notification("EchoBodyHandler")
+        test_notification()
         |> Notification.add_webpush(test_webpush())
 
       assert :ok == Sparrow.FCM.V1.push(@pool_name, notification)
@@ -215,7 +215,7 @@ defmodule Sparrow.FCM.V1Test do
         {:ok, {headers, r.body}}
       end do
       notification =
-        test_notification_without_optional_args("EchoBodyHandler")
+        test_notification_without_optional_args()
         |> Notification.add_apns(test_apns())
 
       assert :ok == Sparrow.FCM.V1.push(@pool_name, notification)
@@ -344,22 +344,20 @@ defmodule Sparrow.FCM.V1Test do
     assert :ok == Sparrow.FCM.V1.process_response({:ok, {headers, body}})
   end
 
-  defp test_notification(project_id) do
+  defp test_notification() do
     Notification.new(
       @notification_target_type,
       @notification_target,
-      project_id,
       @notification_title,
       @notification_body,
       @notification_data
     )
   end
 
-  defp test_notification_without_optional_args(project_id) do
+  defp test_notification_without_optional_args() do
     Notification.new(
       @notification_target_type,
-      @notification_target,
-      project_id
+      @notification_target
     )
   end
 

--- a/test/sparrow_test.exs
+++ b/test/sparrow_test.exs
@@ -8,7 +8,7 @@ defmodule SparrowTest do
   @path "/3/device/"
   @cert_path "priv/ssl/client_cert.pem"
   @key_path "priv/ssl/client_key.pem"
-  @project_id "OkFCMHandler"
+  @project_id "sparrow-test-id"
 
   setup do
     {:ok, cowboy_pid, cowboys_name} =
@@ -135,15 +135,15 @@ defmodule SparrowTest do
         Sparrow.FCM.V1.Android.new()
         |> Sparrow.FCM.V1.Android.add_title("dummy title")
 
-      notiifcation =
-        Sparrow.FCM.V1.Notification.new(:topic, "news", @project_id)
+      notification =
+        Sparrow.FCM.V1.Notification.new(:topic, "news")
         |> Sparrow.FCM.V1.Notification.add_android(android)
 
-      assert :ok == Sparrow.API.push(notiifcation)
-      assert :ok == Sparrow.API.push(notiifcation, [:yippee_ki_yay])
+      assert :ok == Sparrow.API.push(notification)
+      assert :ok == Sparrow.API.push(notification, [:yippee_ki_yay])
 
       assert {:error, :configuration_error} ==
-               Sparrow.API.push(notiifcation, [
+               Sparrow.API.push(notification, [
                  :yippee_ki_yay,
                  :wrong_tag
                ])
@@ -182,7 +182,7 @@ defmodule SparrowTest do
         |> Sparrow.FCM.V1.Android.add_title("dummy title")
 
       notiifcation =
-        Sparrow.FCM.V1.Notification.new(:topic, "news", @project_id)
+        Sparrow.FCM.V1.Notification.new(:topic, "news")
         |> Sparrow.FCM.V1.Notification.add_android(android)
 
       assert :ok == Sparrow.API.push(notiifcation)


### PR DESCRIPTION
## Description

This PR adds project id bearer for FCM. Till now user had to manually add project ID to each notification no it is done for him. Project ID is taken from FCM provided json file.

## Motivation and Context

Project ID had to be found stored somehow and added to each FCM push notification manually. Now it automatised completely. So no chance to use wrong project ID. Project IDs are assigned to pools by pools name. 

## How Has This Been Tested?

No new tests are required. It can be  tested by existing tests, after these tests are corrected.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds a functionality)
- [ ] Breaking change (fix or feature that would cause an existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added tests to **TEST** my changes.
- [x] All new and existing tests passed.

- [ ] Builds corresponding to the PR have passed.

