### PR TITLE
Make PoolWarden start without configuration as well

### DIFF
--- a/lib/sparrow.ex
+++ b/lib/sparrow.ex
@@ -15,15 +15,11 @@ defmodule Sparrow do
   @spec start({Keyword.t(), Keyword.t()}) :: Supervisor.on_start()
   def start({raw_fcm_config, raw_apns_config}) do
     children =
-      if raw_apns_config == nil and raw_fcm_config == nil do
-        []
-      else
         [
           Sparrow.PoolsWarden
         ]
         |> maybe_append({Sparrow.FCM.V1.Supervisor, raw_fcm_config})
         |> maybe_append({Sparrow.APNS.Supervisor, raw_apns_config})
-      end
 
     opts = [strategy: :one_for_one]
     Supervisor.start_link(children, opts)

--- a/lib/sparrow/apns/notification.ex
+++ b/lib/sparrow/apns/notification.ex
@@ -76,7 +76,7 @@ defmodule Sparrow.APNS.Notification do
 
   ## Arguments
       *`device_token` - Token of the device you want to send notification to.
-      *`type` - Notiifcation type determins weater notification is development (`:dev`) or production (`:prod`) type.
+      *`type` - Notification type determines whether notification is development (`:dev`) or production (`:prod`) type.
   """
   @spec new(String.t(), notification_mode) :: __MODULE__.t()
   def new(device_token, type) do


### PR DESCRIPTION
* Removed the condition stating that PoolWarden may only start when either APNS or FCM configuration is set
* Corrected a few typos in docstrings