### PR TITLE
Make Goth runtime dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,9 @@ defmodule Sparrow.MixProject do
 
   def application do
     [
-      extra_applications: [:logger],
+      # Goth has to be set as `runtime: false` to prevent it from
+      # auto-starting, but we still need it in the release
+      extra_applications: [:logger, :goth],
       mod: {Sparrow, []}
     ]
   end


### PR DESCRIPTION
Goth is used in runtime, yet it's marked as `runtime: false` in order to disable its auto-start. This means, it has to be added to `extra_applications` in order to include it for release.