### PR TITLE
Add is connection alive check to h2 worker

### DIFF
--- a/lib/sparrow/h2_worker.ex
+++ b/lib/sparrow/h2_worker.ex
@@ -271,6 +271,14 @@ defmodule Sparrow.H2Worker do
     |> State.reset_requests_collection()
   end
 
+  def is_alive_connection(pid) do
+    GenServer.call(pid, :is_alive_connection)
+  end
+
+  def handle_call(:is_alive_connection, _from, state) do
+    {:reply, state.connection_ref != nil, state}
+  end
+
   @spec handle_call({:send_request, request}, from, state) ::
           {:noreply, state} | {:stop, reason, state}
   def handle_call({:send_request, request}, from, state) do

--- a/test/h2_worker_test.exs
+++ b/test/h2_worker_test.exs
@@ -15,6 +15,7 @@ defmodule Sparrow.H2WorkerTest do
   alias Sparrow.H2Worker.Request, as: OuterRequest
   alias Sparrow.H2Worker.State
 
+  alias Sparrow.H2Worker.Authentication.TokenBased, as: TokenBasedAuth
   @repeats 2
 
   import Helpers.SetupHelper, only: [passthrough_h2: 1]
@@ -764,14 +765,12 @@ defmodule Sparrow.H2WorkerTest do
           :ok
         end,
         close: fn _ -> :ok end do
-        auth =
-          Sparrow.H2Worker.Authentication.TokenBased.new(fn -> "dummyToken" end)
 
         config =
           Config.new(%{
             domain: domain,
             port: port,
-            authentication: auth,
+            authentication: TokenBasedAuth.new(fn -> "dummyToken" end),
             tls_options: tls_options,
             ping_interval: ping_interval
           })


### PR DESCRIPTION
This PR adds a function which allows checking if h2worker connection is alive.

## Description

Adds a function which allows checking if h2worker connection is alive.

## Motivation and Context

This change is needed for providing reliable pool connections count metric.

## How Has This Been Tested?

Thoroughly and severely.
Tests were added for both cases:
 - h2worker not connected -> `is_alive_connection/1` returns `false` 
 - h2worker connected -> `is_alive_connection/1` returns `true` 

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added tests to **TEST** my changes.
- [x] All new and existing tests passed.

- [x] Builds corresponding to the PR have passed.

