### PR TITLE
Enable creation of APNs object for FCM request without auth token

### DIFF
--- a/lib/sparrow/fcm/v1/apns.ex
+++ b/lib/sparrow/fcm/v1/apns.ex
@@ -5,7 +5,7 @@ defmodule Sparrow.FCM.V1.APNS do
   FCM wrapper for `Sparrow.APNS.Notification`.
   """
 
-  @type token_getter :: (-> {String.t(), String.t()})
+  @type token_getter :: (-> {String.t(), String.t()}) | nil
   @type t :: %__MODULE__{
           notification: Sparrow.APNS.Notification.t(),
           token_getter: token_getter
@@ -25,7 +25,7 @@ defmodule Sparrow.FCM.V1.APNS do
   """
   @spec new(Sparrow.APNS.Notification.t(), token_getter) ::
           Sparrow.FCM.V1.APNS.t()
-  def new(notification, token_getter) do
+  def new(notification, token_getter \\ nil) do
     %__MODULE__{
       notification: notification,
       token_getter: token_getter
@@ -37,8 +37,14 @@ defmodule Sparrow.FCM.V1.APNS do
   """
   @spec to_map(t) :: map
   def to_map(apns) do
+    auth_header =
+      case apns.token_getter do
+        nil -> []
+        token_getter -> [token_getter.()]
+      end
+
     %{
-      :headers => Map.new([apns.token_getter.() | apns.notification.headers]),
+      :headers => Map.new(auth_header ++ apns.notification.headers),
       :payload => Sparrow.APNS.make_body(apns.notification)
     }
   end

--- a/test/fcm/v1/apns_config_test.exs
+++ b/test/fcm/v1/apns_config_test.exs
@@ -4,7 +4,7 @@ defmodule Sparrow.FCM.V1.APNSTest do
   alias Sparrow.APNS.Notification
   alias Sparrow.FCM.V1.APNS
 
-  test "apns config is built correcly" do
+  test "apns config is created correcly" do
     token_getter = fn -> {"authorization", "Bearer dummy token"} end
 
     apns_notification =
@@ -17,5 +17,60 @@ defmodule Sparrow.FCM.V1.APNSTest do
 
     assert token_getter == apns.token_getter
     assert apns_notification == apns.notification
+  end
+
+  test "apns config is built correcly" do
+    token_getter = fn -> {"authorization", "Bearer dummy token"} end
+
+    apns_notification =
+      "dummy device token"
+      |> Notification.new(:dev)
+      |> Notification.add_title("apns title")
+      |> Notification.add_body("apns body")
+      |> Notification.add_apns_id("apns id")
+
+    apns_config =
+      APNS.new(apns_notification, token_getter)
+      |> APNS.to_map()
+
+    assert %{headers: headers, payload: payload} = apns_config
+    assert headers["apns-id"] == "apns id"
+    assert headers["authorization"] == "Bearer dummy token"
+
+    assert %{"aps" => %{"alert" => %{title: "apns title", body: "apns body"}}} ==
+             payload
+  end
+
+  test "apns config is created correcly without token getter" do
+    apns_notification =
+      "dummy device token"
+      |> Notification.new(:dev)
+      |> Notification.add_title("apns title")
+      |> Notification.add_body("apns body")
+
+    apns = APNS.new(apns_notification)
+
+    assert nil == apns.token_getter
+    assert apns_notification == apns.notification
+  end
+
+  test "apns config is built correcly without token getter" do
+    apns_notification =
+      "dummy device token"
+      |> Notification.new(:dev)
+      |> Notification.add_title("apns title")
+      |> Notification.add_body("apns body")
+      |> Notification.add_apns_id("apns id")
+
+    apns_config =
+      APNS.new(apns_notification)
+      |> APNS.to_map()
+
+    assert %{headers: headers, payload: payload} = apns_config
+    assert headers["apns-id"] == "apns id"
+    assert headers["authorization"] == nil
+
+    assert %{"aps" => %{"alert" => %{title: "apns title", body: "apns body"}}} ==
+             payload
   end
 end


### PR DESCRIPTION
## Description

This PR introduces a possibility to create an APNs object for FCM request without providing `token_getter` value. When it's not provided then `Authorization` header is not being added to the payload.

## Motivation and Context

This change is motivated by an issue in MongoosePush repository - https://github.com/esl/MongoosePush/issues/209. We want to enable configuring MongoosePush to integrate only with FCM and let FCM handle the communication with APNs. However, as stated in the Firebase [documentation](https://firebase.flutter.dev/docs/messaging/apple-integration/#linking-apns-with-fcm) an administrator should put the authentication key in FCM to link them, so requests to FCM don't need to have an APNs token attached.

## How Has This Been Tested?

Unit tests are created for this.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds a functionality)
- [ ] Breaking change (fix or feature that would cause an existing functionality to change)
