### PR TITLE
Accept wildcard certificates in default TLS options

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,14 @@ Do your work in the branch, push it to the ESL repository if you have access to 
 
 ### Run tests
 
-When done, run `mix test` and write tests related to what you've done.
+Generate the test certificates first, then run the suite:
+
+```
+mix sparrow.certs.dev
+mix test
+```
+
+Write tests related to what you've done.
 
 ### Check coding style
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ Currently it provides support for the following APIs:
 * Elixir 1.13 or higher
 * Erlang OTP 24 or higher
 
+## Running tests
+The suite needs local certificates, generated once by a Mix task. Requires `openssl`.
+
+```
+mix sparrow.certs.dev
+mix test
+```
+
 # Build sparrow config
 This section describes how to write a config file for Sparrow.
 If you wish to use just one of the following services, do not include the other in the config.

--- a/README.md
+++ b/README.md
@@ -12,14 +12,6 @@ Currently it provides support for the following APIs:
 * Elixir 1.13 or higher
 * Erlang OTP 24 or higher
 
-## Running tests
-The suite needs local certificates, generated once by a Mix task. Requires `openssl`.
-
-```
-mix sparrow.certs.dev
-mix test
-```
-
 # Build sparrow config
 This section describes how to write a config file for Sparrow.
 If you wish to use just one of the following services, do not include the other in the config.

--- a/lib/mix/tasks/sparrow_certs_dev.ex
+++ b/lib/mix/tasks/sparrow_certs_dev.ex
@@ -37,6 +37,7 @@ defmodule Mix.Tasks.Sparrow.Certs.Dev do
     maybe_gen_dev_apns()
     maybe_gen_prod_apns()
     maybe_gen_https()
+    maybe_gen_wildcard_https()
     maybe_gen_test_client()
   end
 
@@ -77,15 +78,46 @@ defmodule Mix.Tasks.Sparrow.Certs.Dev do
     )
   end
 
-  defp maybe_gen_cert(cert_file, key_file, common_name, extensions \\ []) do
+  # Covers "*.sparrow.test" by a wildcard SAN only, mirroring the certificate
+  # Google serves for "fcm.googleapis.com". Used to test that the default TLS
+  # options accept wildcard certificates. Issued by its own small CA because
+  # `:ssl` rejects a self-signed peer certificate outright, before it ever gets
+  # as far as checking the hostname.
+  defp maybe_gen_wildcard_https do
+    ca_cert = "priv/ssl/wildcard_ca_cert.pem"
+    ca_key = "priv/ssl/wildcard_ca_key.pem"
+
+    maybe_gen_cert(
+      ca_cert,
+      ca_key,
+      "sparrow-test-ca",
+      [{"basicConstraints", "critical,CA:TRUE"}]
+    )
+
+    maybe_gen_cert(
+      "priv/ssl/wildcard_cert.pem",
+      "priv/ssl/wildcard_key.pem",
+      "*.sparrow.test",
+      [{"subjectAltName", "DNS:*.sparrow.test"}],
+      {ca_cert, ca_key}
+    )
+  end
+
+  defp maybe_gen_cert(
+         cert_file,
+         key_file,
+         common_name,
+         extensions \\ [],
+         signer \\ :self
+       ) do
     if File.exists?(cert_file) and File.exists?(key_file) do
       :ok
     else
-      gen_cert(cert_file, key_file, common_name, extensions)
+      gen_cert(cert_file, key_file, common_name, extensions, signer)
     end
   end
 
-  defp gen_cert(cert_file, key_file, common_name, extensions) do
+  defp gen_cert(cert_file, key_file, common_name, extensions, signer) do
     cert_dir = Path.dirname(cert_file)
     key_dir = Path.dirname(key_file)
 
@@ -95,7 +127,7 @@ defmodule Mix.Tasks.Sparrow.Certs.Dev do
     ext_file = openssl_tmp_extfile(extensions)
 
     req_file = create_csr!(common_name, key_file, cert_file)
-    :ok = sign_csr!(req_file, key_file, ext_file, cert_file)
+    :ok = sign_csr!(req_file, key_file, ext_file, cert_file, signer)
 
     :ok = File.rm!(ext_file)
     :ok = File.rm!(req_file)
@@ -124,24 +156,34 @@ defmodule Mix.Tasks.Sparrow.Certs.Dev do
     req_file
   end
 
-  defp sign_csr!(req_file, key_file, ext_file, cert_file) do
+  defp sign_csr!(req_file, key_file, ext_file, cert_file, signer) do
     {_, 0} =
-      System.cmd("openssl", [
-        "x509",
-        "-req",
-        "-days",
-        "365",
-        "-in",
-        req_file,
-        "-signkey",
-        key_file,
-        "-extfile",
-        ext_file,
-        "-out",
-        cert_file
-      ])
+      System.cmd(
+        "openssl",
+        [
+          "x509",
+          "-req",
+          "-days",
+          "365",
+          "-in",
+          req_file,
+          "-extfile",
+          ext_file,
+          "-out",
+          cert_file
+        ] ++ signer_args(signer, key_file)
+      )
 
     :ok
+  end
+
+  # Either self-signed with the certificate's own key, or issued by a CA.
+  defp signer_args(:self, key_file) do
+    ["-signkey", key_file]
+  end
+
+  defp signer_args({ca_cert_file, ca_key_file}, _key_file) do
+    ["-CA", ca_cert_file, "-CAkey", ca_key_file, "-CAcreateserial"]
   end
 
   defp openssl_tmp_extfile(extensions) do
@@ -149,13 +191,21 @@ defmodule Mix.Tasks.Sparrow.Certs.Dev do
     # Make sure the file exists even if there are no extensions
     _ = File.touch(ext_file)
 
-    for {ext_id, ext_bin} <- extensions do
-      ext_id = extn_id_to_string(ext_id)
-      ext_bin = Base.encode16(ext_bin)
-      :ok = File.write!(ext_file, ~s"#{ext_id}=DER:#{ext_bin}\n", [:append])
+    for extension <- extensions do
+      :ok = File.write!(ext_file, extension_line(extension), [:append])
     end
 
     ext_file
+  end
+
+  # Extensions are given either as {oid_tuple, der_binary}, written out in
+  # OpenSSL's DER form, or as {name, value} strings written out verbatim.
+  defp extension_line({ext_id, ext_bin}) when is_tuple(ext_id) do
+    ~s"#{extn_id_to_string(ext_id)}=DER:#{Base.encode16(ext_bin)}\n"
+  end
+
+  defp extension_line({ext_name, ext_value}) when is_binary(ext_name) do
+    ~s"#{ext_name}=#{ext_value}\n"
   end
 
   defp extn_id_to_string(extn_id) do

--- a/lib/sparrow/apns/pool/supervisor.ex
+++ b/lib/sparrow/apns/pool/supervisor.ex
@@ -106,7 +106,9 @@ defmodule Sparrow.APNS.Pool.Supervisor do
     [
       {:verify, :verify_peer},
       {:depth, 99},
-      {:cacerts, cacerts}
+      {:cacerts, cacerts},
+      {:customize_hostname_check,
+       [match_fun: :public_key.pkix_verify_hostname_match_fun(:https)]}
     ]
   end
 end

--- a/lib/sparrow/fcm/v1/pool/supervisor.ex
+++ b/lib/sparrow/fcm/v1/pool/supervisor.ex
@@ -87,7 +87,9 @@ defmodule Sparrow.FCM.V1.Pool.Supervisor do
     [
       {:verify, :verify_peer},
       {:depth, 99},
-      {:cacerts, cacerts}
+      {:cacerts, cacerts},
+      {:customize_hostname_check,
+       [match_fun: :public_key.pkix_verify_hostname_match_fun(:https)]}
     ]
   end
 end

--- a/test/h2_integration/wildcard_certificate_test.exs
+++ b/test/h2_integration/wildcard_certificate_test.exs
@@ -1,0 +1,183 @@
+defmodule H2Integration.WildcardCertificateTest do
+  @moduledoc """
+  Regression tests for wildcard certificate support in the pool supervisors'
+  default TLS options.
+  """
+  use ExUnit.Case, async: false
+
+  alias Helpers.SetupHelper, as: Setup
+  alias Sparrow.H2Worker.Request, as: OuterRequest
+
+  import Mox
+  setup :set_mox_global
+
+  import Helpers.SetupHelper, only: [passthrough_h2: 1]
+  setup :passthrough_h2
+
+  @client_cert "priv/ssl/client_cert.pem"
+  @client_key "priv/ssl/client_key.pem"
+
+  # Covered by the wildcard SAN "DNS:*.sparrow.test" and nothing else, so it
+  # only resolves against the certificate if wildcard matching is enabled.
+  @wildcard_cert "priv/ssl/wildcard_cert.pem"
+  @wildcard_key "priv/ssl/wildcard_key.pem"
+  @wildcard_ca_cert "priv/ssl/wildcard_ca_cert.pem"
+  @wildcard_host ~c"pool.sparrow.test"
+
+  @fcm_service_account "sparrow_token.json"
+  @pool_name :wildcard_cert_pool
+
+  setup do
+    :ok = :ssl.start()
+    # Not configured in the test env, but FCM's `init/1` registers project ids.
+    start_supervised!(Sparrow.FCM.V1.ProjectIdBearer)
+    :ok
+  end
+
+  describe "default TLS options" do
+    test "FCM pool enables wildcard hostname matching" do
+      assert Keyword.has_key?(
+               fcm_default_tls_options(),
+               :customize_hostname_check
+             )
+    end
+
+    test "APNS pool enables wildcard hostname matching" do
+      assert Keyword.has_key?(
+               apns_default_tls_options(),
+               :customize_hostname_check
+             )
+    end
+
+    test "peer verification stays enabled" do
+      for tls_options <- [fcm_default_tls_options(), apns_default_tls_options()] do
+        assert Keyword.fetch!(tls_options, :verify) == :verify_peer
+      end
+    end
+  end
+
+  describe "handshake against a wildcard-only certificate" do
+    test "FCM defaults accept it" do
+      port = start_wildcard_tls_server()
+
+      assert :ok == connect(port, fcm_default_tls_options())
+    end
+
+    test "APNS defaults accept it" do
+      port = start_wildcard_tls_server()
+
+      assert :ok == connect(port, apns_default_tls_options())
+    end
+
+    # Guards the tests above: without the option the handshake must fail, and
+    # fail specifically on the hostname check rather than on path validation.
+    test "it is rejected without customize_hostname_check" do
+      port = start_wildcard_tls_server()
+
+      tls_options =
+        Keyword.delete(fcm_default_tls_options(), :customize_hostname_check)
+
+      assert {:error, {:tls_alert, {:handshake_failure, reason}}} =
+               connect(port, tls_options)
+
+      assert to_string(reason) =~ "hostname_check_failed"
+    end
+
+    # The handshake tests above drive `:ssl` directly. This one goes through a
+    # real pool, so it also covers the tls_opts reaching `:ssl.connect`
+    # unchanged through the H2 client.
+    test "an FCM pool serves a request over it" do
+      port = start_wildcard_tls_server()
+
+      config =
+        Sparrow.H2Worker.Config.new(%{
+          domain: Setup.server_host(),
+          port: port,
+          authentication:
+            Sparrow.H2Worker.Authentication.TokenBased.new(fn ->
+              {"authorization", "bearer dummy_token"}
+            end),
+          tls_options: client_options(fcm_default_tls_options())
+        })
+
+      config
+      |> Sparrow.H2Worker.Pool.Config.new(@pool_name)
+      |> Sparrow.H2Worker.Pool.start_unregistered(:fcm, [])
+
+      request =
+        OuterRequest.new(
+          Setup.default_headers(),
+          "",
+          "/OkResponseHandler",
+          2_000
+        )
+
+      assert {:ok, {headers, _body}} =
+               Sparrow.H2Worker.Pool.send_request(@pool_name, request)
+
+      assert Enum.member?(headers, {":status", "200"})
+    end
+  end
+
+  defp fcm_default_tls_options do
+    [[path_to_json: @fcm_service_account]]
+    |> Sparrow.FCM.V1.Pool.Supervisor.init()
+    |> tls_options_from_init()
+  end
+
+  defp apns_default_tls_options do
+    [
+      dev: [
+        [auth_type: :certificate_based, cert: @client_cert, key: @client_key]
+      ]
+    ]
+    |> Sparrow.APNS.Pool.Supervisor.init()
+    |> tls_options_from_init()
+  end
+
+  # The supervisors build their pool configs in `init/1`, so the defaults are
+  # read back off the child spec rather than duplicated here.
+  defp tls_options_from_init({:ok, {_sup_flags, children}}) do
+    [%{start: {Sparrow.H2Worker.Pool, :start_link, [pool_config | _]}}] =
+      children
+
+    pool_config.workers_config.tls_options
+  end
+
+  defp start_wildcard_tls_server do
+    {:ok, _pid, name} =
+      [
+        {":_",
+         [{"/OkResponseHandler", Helpers.CowboyHandlers.OkResponseHandler, []}]}
+      ]
+      |> :cowboy_router.compile()
+      |> Setup.start_cowboy_tls(
+        certificate_required: :no,
+        certfile: @wildcard_cert,
+        keyfile: @wildcard_key,
+        name: :wildcard_cert_listener
+      )
+
+    on_exit(fn -> :cowboy.stop_listener(name) end)
+
+    :ranch.get_port(name)
+  end
+
+  # Overrides only the trust anchor and the reference hostname; the rest is as
+  # the supervisors built it. `:cacerts` must be deleted, not overridden — while
+  # it is set `:ssl` silently ignores `:cacertfile`. SNI is the identity the
+  # certificate is checked against, so it is what puts the wildcard under test.
+  defp client_options(tls_options) do
+    tls_options
+    |> Keyword.delete(:cacerts)
+    |> Keyword.put(:cacertfile, @wildcard_ca_cert)
+    |> Keyword.put(:server_name_indication, @wildcard_host)
+  end
+
+  defp connect(port, tls_options) do
+    case :ssl.connect(~c"localhost", port, client_options(tls_options), 5_000) do
+      {:ok, socket} -> :ssl.close(socket)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+end

--- a/test/h2_integration/wildcard_certificate_test.exs
+++ b/test/h2_integration/wildcard_certificate_test.exs
@@ -34,6 +34,25 @@ defmodule H2Integration.WildcardCertificateTest do
     :ok
   end
 
+  setup_all do
+    {:ok, _cowboy_pid, cowboys_name} =
+      [
+        {":_",
+         [{"/OkResponseHandler", Helpers.CowboyHandlers.OkResponseHandler, []}]}
+      ]
+      |> :cowboy_router.compile()
+      |> Setup.start_cowboy_tls(
+        certificate_required: :no,
+        certfile: @wildcard_cert,
+        keyfile: @wildcard_key,
+        name: :wildcard_cert_listener
+      )
+
+    on_exit(fn -> :cowboy.stop_listener(cowboys_name) end)
+
+    {:ok, port: :ranch.get_port(cowboys_name)}
+  end
+
   describe "default TLS options" do
     test "FCM pool enables wildcard hostname matching" do
       assert Keyword.has_key?(
@@ -57,23 +76,17 @@ defmodule H2Integration.WildcardCertificateTest do
   end
 
   describe "handshake against a wildcard-only certificate" do
-    test "FCM defaults accept it" do
-      port = start_wildcard_tls_server()
-
+    test "FCM defaults accept it", %{port: port} do
       assert :ok == connect(port, fcm_default_tls_options())
     end
 
-    test "APNS defaults accept it" do
-      port = start_wildcard_tls_server()
-
+    test "APNS defaults accept it", %{port: port} do
       assert :ok == connect(port, apns_default_tls_options())
     end
 
     # Guards the tests above: without the option the handshake must fail, and
     # fail specifically on the hostname check rather than on path validation.
-    test "it is rejected without customize_hostname_check" do
-      port = start_wildcard_tls_server()
-
+    test "it is rejected without customize_hostname_check", %{port: port} do
       tls_options =
         Keyword.delete(fcm_default_tls_options(), :customize_hostname_check)
 
@@ -86,9 +99,7 @@ defmodule H2Integration.WildcardCertificateTest do
     # The handshake tests above drive `:ssl` directly. This one goes through a
     # real pool, so it also covers the tls_opts reaching `:ssl.connect`
     # unchanged through the H2 client.
-    test "an FCM pool serves a request over it" do
-      port = start_wildcard_tls_server()
-
+    test "an FCM pool serves a request over it", %{port: port} do
       config =
         Sparrow.H2Worker.Config.new(%{
           domain: Setup.server_host(),
@@ -142,25 +153,6 @@ defmodule H2Integration.WildcardCertificateTest do
       children
 
     pool_config.workers_config.tls_options
-  end
-
-  defp start_wildcard_tls_server do
-    {:ok, _pid, name} =
-      [
-        {":_",
-         [{"/OkResponseHandler", Helpers.CowboyHandlers.OkResponseHandler, []}]}
-      ]
-      |> :cowboy_router.compile()
-      |> Setup.start_cowboy_tls(
-        certificate_required: :no,
-        certfile: @wildcard_cert,
-        keyfile: @wildcard_key,
-        name: :wildcard_cert_listener
-      )
-
-    on_exit(fn -> :cowboy.stop_listener(name) end)
-
-    :ranch.get_port(name)
   end
 
   # Overrides only the trust anchor and the reference hostname; the rest is as

--- a/test/helpers/setup_helper.ex
+++ b/test/helpers/setup_helper.ex
@@ -69,37 +69,41 @@ defmodule Helpers.SetupHelper do
     })
   end
 
-  defp certificate_settings_list do
+  # `certfile`/`keyfile` let a test serve its own certificate; the defaults are
+  # the generic ones from `mix sparrow.certs.dev`.
+  defp certificate_settings_list(opts) do
+    certfile = Keyword.get(opts, :certfile, "priv/ssl/fake_cert.pem")
+
     [
-      {:cacertfile, "priv/ssl/fake_cert.pem"},
-      {:certfile, "priv/ssl/fake_cert.pem"},
-      {:keyfile, "priv/ssl/fake_key.pem"}
+      {:cacertfile, Keyword.get(opts, :cacertfile, certfile)},
+      {:certfile, certfile},
+      {:keyfile, Keyword.get(opts, :keyfile, "priv/ssl/fake_key.pem")}
     ]
   end
 
-  defp settings_list(:positive_cerificate_verification, port) do
+  defp settings_list(:positive_cerificate_verification, port, opts) do
     [
       {:port, port},
       {:verify, :verify_peer},
       {:verify_fun, {fn _, _, _ -> {:valid, :ok} end, :ok}}
-      | certificate_settings_list()
+      | certificate_settings_list(opts)
     ]
   end
 
-  defp settings_list(:negative_cerificate_verification, port) do
+  defp settings_list(:negative_cerificate_verification, port, opts) do
     [
       {:port, port},
       {:verify, :verify_peer},
       {:verify_fun,
        {fn _, _, _ -> {:fail, :negative_cerificate_verification} end, :ok}}
-      | certificate_settings_list()
+      | certificate_settings_list(opts)
     ]
   end
 
-  defp settings_list(:no, port) do
+  defp settings_list(:no, port, opts) do
     [
       {:port, port}
-      | certificate_settings_list()
+      | certificate_settings_list(opts)
     ]
   end
 
@@ -107,7 +111,7 @@ defmodule Helpers.SetupHelper do
     cert_required = Keyword.get(opts, :certificate_required, :no)
     port = Keyword.get(opts, :port, 0)
     name = Keyword.get(opts, :name, :look)
-    settings_list = settings_list(cert_required, port)
+    settings_list = settings_list(cert_required, port, opts)
 
     {:ok, pid} =
       :cowboy.start_tls(


### PR DESCRIPTION
## Description

`setup_default_tls_options/0` in the FCM and APNS pool supervisors does not set `customize_hostname_check`, so Erlang's `:ssl` falls back to its default hostname match function, which rejects wildcard SAN entries. This sets the HTTPS match fun in both. Peer verification is unchanged, and callers passing their own `tls_opts` are unaffected.

## Motivation and Context

Google's certificate for `fcm.googleapis.com` is now covered only by the wildcard `*.googleapis.com`, so FCM pools running on the default TLS options fail the handshake with `{bad_cert,hostname_check_failed}` and retry every 5s. The trigger was external, so existing deployments broke with no change on their side.

APNS is not affected today — Apple still serves exact-match SANs — but its defaults were identical and would fail the same way.

Full analysis, including Certificate Transparency data: esl/MongoosePush#231
Jira: [MIM-2773](https://erlangsolutions.atlassian.net/browse/MIM-2773)

## How Has This Been Tested?

New `test/pool_supervisor_tls_test.exs` reads the defaults back out of each supervisor's public `init/1` rather than duplicating the options list, then runs a real handshake against a certificate covered by a wildcard SAN only. With the fix reverted, 4 of its 6 tests fail with `{bad_cert,hostname_check_failed}`.

Also verified against the live endpoints: `fcm.googleapis.com` fails before and connects after; `api.push.apple.com` connects either way.

`mix sparrow.certs.dev` now generates the wildcard fixture. CI already runs it before `mix test`, so no CI change is needed.
